### PR TITLE
Change to use custom controls provided by video driver

### DIFF
--- a/ikvm_server.hpp
+++ b/ikvm_server.hpp
@@ -176,8 +176,8 @@ class Server
                                          "       oxo          "
                                          "        o           ";
 
-    static constexpr int FULL_FRAME_COUNT = 5;
-    int compareModeCounter;
+    static constexpr int COMPLETE_FRAME_COUNT = 5;
+    int captureModeCounter;
 
     /* Dump FPS every 10 seconds */
     static constexpr int FPS_DUMP_RATE = 10;

--- a/ikvm_video.hpp
+++ b/ikvm_video.hpp
@@ -112,10 +112,9 @@ class Video
         subSampling = _sub;
     }
 
-    unsigned int getClip(unsigned int *x, unsigned int *y, unsigned int *w,
-                         unsigned int *h);
+    unsigned int getRectCount();
 
-    void setCompareMode(bool enable);
+    void setCaptureMode(bool completeFrame);
 
     /* @brief Number of bits per component of a pixel */
     static const int bitsPerSample;

--- a/npcm-video.h
+++ b/npcm-video.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
+/*
+ * Controls header for NPCM video driver
+ *
+ * Copyright (C) 2022 Nuvoton Technologies
+ */
+
+#ifndef _UAPI_LINUX_NPCM_VIDEO_H
+#define _UAPI_LINUX_NPCM_VIDEO_H
+
+#include <linux/v4l2-controls.h>
+
+/*
+ * Check Documentation/userspace-api/media/drivers/npcm-video.rst for control
+ * details.
+ */
+
+/*
+ * This control is meant to set the mode of NPCM Video Capture/Differentiation
+ * (VCD) engine.
+ *
+ * The VCD engine supports two modes:
+ * COMPLETE - Capture the next complete frame into memory.
+ * DIFF	    - Compare the incoming frame with the frame stored in memory, and
+ *	      updates the differentiated frame in memory.
+ */
+#define V4L2_CID_NPCM_CAPTURE_MODE	(V4L2_CID_USER_BASE + 0x11b0 + 0)
+
+enum v4l2_npcm_capture_mode {
+	V4L2_NPCM_CAPTURE_MODE_COMPLETE	= 0, /* COMPLETE mode */
+	V4L2_NPCM_CAPTURE_MODE_DIFF	= 1, /* DIFF mode */
+};
+
+/*
+ * This control is meant to get the count of compressed HEXTILE rectangles which
+ * is relevant to the number of differentiated frames if VCD is in DIFF mode.
+ * And the count will always be 1 if VCD is in COMPLETE mode.
+ */
+#define V4L2_CID_NPCM_RECT_COUNT	(V4L2_CID_USER_BASE + 0x11b0 + 1)
+
+#endif /* _UAPI_LINUX_NPCM_VIDEO_H */


### PR DESCRIPTION
Change to use custom controls provided by video driver. This commit has to go with below kernel commits.

NPCM-5.15-OpenBMC:
af8da1856f76 ("media: nuvoton: Support custom controls")

NPCM-5.10-OpenBMC:
8d376993acbb ("media: nuvoton: Support custom controls")