### PR TITLE
Add SW encoding support

### DIFF
--- a/ikvm_manager.cpp
+++ b/ikvm_manager.cpp
@@ -21,6 +21,7 @@ void Manager::run()
     {
         if (server.wantsFrame())
         {
+            server.checkClientFormat();
             video.start();
             server.sendFrame();
         }

--- a/ikvm_server.hpp
+++ b/ikvm_server.hpp
@@ -86,6 +86,7 @@ class Server
         return video;
     }
 
+    void checkClientFormat();
     void dumpFps();
 
   private:
@@ -188,6 +189,9 @@ class Server
                                     int compressedLen);
 
     void rfbNuInitRfbFormat(rfbScreenInfoPtr screen);
+    void rfbNuNewFramebuffer(rfbScreenInfoPtr screen, char* framebuffer,
+                             int width, int height, int bitsPerSample,
+                             int samplesPerPixel, int bytesPerPixel);
 };
 
 } // namespace ikvm

--- a/ikvm_video.cpp
+++ b/ikvm_video.cpp
@@ -468,6 +468,15 @@ void Video::start()
 
     memset(&fmt, 0, sizeof(v4l2_format));
     fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    fmt.fmt.pix.pixelformat = pixelformat;
+
+    rc = ioctl(fd, VIDIOC_S_FMT, &fmt);
+    if (rc < 0)
+    {
+        log<level::ERR>("Failed to set format",
+                        entry("ERROR=%s", strerror(errno)));
+    }
+
     rc = ioctl(fd, VIDIOC_G_FMT, &fmt);
     if (rc < 0)
     {
@@ -503,6 +512,9 @@ void Video::start()
 
     height = fmt.fmt.pix.height;
     width = fmt.fmt.pix.width;
+
+    pixelformat = fmt.fmt.pix.pixelformat;
+    rfbLog("pixelformat fourcc = %x\n", pixelformat);
 
     resize();
 

--- a/ikvm_video.hpp
+++ b/ikvm_video.hpp
@@ -85,6 +85,15 @@ class Video
         return height;
     }
     /*
+     * @brief Gets the pixel format of the video frame
+     *
+     * @return Value of the pixel format of video frame
+     */
+    inline uint32_t getPixelformat() const
+    {
+        return pixelformat;
+    }
+    /*
      * @brief Gets the width of the video frame
      *
      * @return Value of the width of video frame in pixels
@@ -115,6 +124,11 @@ class Video
     unsigned int getRectCount();
 
     void setCaptureMode(bool completeFrame);
+
+    inline void setPixelformat(uint32_t format)
+    {
+        pixelformat = format;
+    }
 
     /* @brief Number of bits per component of a pixel */
     static const int bitsPerSample;
@@ -170,6 +184,8 @@ class Video
     const std::string path;
     /* @brief Streaming buffer storage */
     std::vector<Buffer> buffers;
+    /* @brief Pixel Format */
+    uint32_t pixelformat;
 };
 
 } // namespace ikvm


### PR DESCRIPTION
Use HW Hextile if client prefers Hextile encoding and supports 16bpp. Otherwise, use SW encoding according to client's settings.

This commit has to go with below kernel commits.

NPCM-6.1-OpenBMC:
9a6e623a19fe ("media: nuvoton: Add RGB565 pixel format support")

NPCM-5.15-OpenBMC:
1b17edf2da68 ("media: nuvoton: Add RGB565 pixel format support")

NPCM-5.10-OpenBMC:
664ac0bd93cb ("media: nuvoton: Add RGB565 pixel format support")