### PR TITLE
Fix disconnect not work in create_usbhid.sh

### DIFF
--- a/create_usbhid.sh
+++ b/create_usbhid.sh
@@ -143,7 +143,7 @@ connect_hid() {
 }
 
 disconnect_hid() {
-    if [[ `cat UDC` =~ "${dev_name}:p" ]]; then
+    if [[ `cat UDC` =~ "${dev_name}" ]]; then
         echo "" > UDC
     fi
 }


### PR DESCRIPTION
Update diconnect_hid function in create_usbhid.sh to match correct UDC name.